### PR TITLE
Fix: Post sorting is not correct

### DIFF
--- a/gulp/lib/dates.js
+++ b/gulp/lib/dates.js
@@ -34,7 +34,11 @@
             return allDatesArray;
         },
         sortFunc: function(a, b) {
-            return new Date(a.date).getTime() < new Date(b.date).getTime();
+            let timeA = new Date(a.date).getTime(),
+                timeB = new Date(b.date).getTime();
+            if (timeA  > timeB) return -1;
+            if (timeA == timeB) return  0;
+            if (timeA  < timeB) return  1;
         }
     };
 })();

--- a/gulp/lib/dates.js
+++ b/gulp/lib/dates.js
@@ -34,7 +34,7 @@
             return allDatesArray;
         },
         sortFunc: function(a, b) {
-            let timeA = new Date(a.date).getTime(),
+            var timeA = new Date(a.date).getTime(),
                 timeB = new Date(b.date).getTime();
             if (timeA  > timeB) return -1;
             if (timeA == timeB) return  0;

--- a/gulp/tests/dates.spec.js
+++ b/gulp/tests/dates.spec.js
@@ -11,8 +11,20 @@
             this.dateStr = 'June 2014';
             this.posts = [
                 { date: '2014-06-11' },
-                { date: '2014-12-11' }
+                { date: '2014-12-11' },
+                { date: '2014-03-11' },
+                { date: '2014-06-11' }
             ];
+        });
+
+        it('Should sort dates correctly', function() {
+            this.posts.sort(dates.sortFunc);
+            expect(this.posts).to.deep.equal([
+                { date: '2014-12-11' },
+                { date: '2014-06-11' },
+                { date: '2014-06-11' },
+                { date: '2014-03-11' }
+            ]);
         });
 
         it('Should create date link', function() {
@@ -25,6 +37,7 @@
 
         it('Should get all dates as links', function() {
             expect(dates.getAllDatesAsLinks('.', this.posts)).to.deep.equal([
+                {dateMonth: '2014-03', dateStr: 'March 2014', dateLink: './date/2014-03'},
                 {dateMonth: '2014-06', dateStr: 'June 2014', dateLink: './date/2014-06'},
                 {dateMonth: '2014-12', dateStr: 'December 2014', dateLink: './date/2014-12'}
             ]);


### PR DESCRIPTION
The current date sorting function only checks if one file a is older than file b, but not the other way around or whether dates are the same. This causes issues where the order the posts are processed in can affect the sorted order of posts.