### PR TITLE
Fix: Automatically generated slug doesn't link correctly

### DIFF
--- a/gulp/lib/compile-options.js
+++ b/gulp/lib/compile-options.js
@@ -15,12 +15,12 @@
                 excerpt = excerpt.replace(/(\r\n|\n|\r)+/gm, ' ');
                 var title = downsize(excerpt, { words: 10 });
 
-                if (!fileData.slug) {
-                    fileData.slug = stringUtils.slugify(title, '-');
-                }
-
                 if (!fileData.title) {
                     fileData.title = title;
+                }
+
+                if (!fileData.slug) {
+                    fileData.slug = stringUtils.slugify(fileData.title, '-');
                 }
 
                 if (!fileData.template && !fileData.date) {


### PR DESCRIPTION
When a post doesn't contain a slug value, a value is generated from the fallback title instead of the actual title; this causes links to fail.